### PR TITLE
refactor: simplify GitHub Actions workflow and update README

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -75,12 +75,6 @@ jobs:
           $linePercent = [math]::Round([double]$lineRate * 100, 2)
           $branchPercent = [math]::Round([double]$branchRate * 100, 2)
           
-          $baseline = 68.79
-          $improvement = $linePercent - $baseline
-          $improvementText = if ($improvement -gt 0) { "⬆️ +$($improvement.ToString('F2'))% 提升" } 
-                            elseif ($improvement -lt 0) { "⬇️ $($improvement.ToString('F2'))% 下降" } 
-                            else { "➡️ 持平" }
-          
           $summary = @"
         ## 📊 覆蓋率報告
         
@@ -88,8 +82,6 @@ jobs:
         |------|------|------|
         | **行覆蓋率** | **$linePercent%** | $linesCovered/$linesValid 行 |
         | **分支覆蓋率** | **$branchPercent%** | $branchesCovered/$branchesValid 分支 |
-        
-        📊 **覆蓋率變化**: $improvementText (基準: $baseline%)
         
         🎯 **測試品質**: 全面覆蓋核心功能和邊界條件
         "@

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 [![Integration Tests](https://github.com/yinchang0626/Further.Strapi/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/yinchang0626/Further.Strapi/actions/workflows/integration-tests.yml)
 [![Tests](https://img.shields.io/badge/tests-71%20passed-brightgreen?logo=github)](https://github.com/yinchang0626/Further.Strapi/actions)
 [![codecov](https://codecov.io/gh/yinchang0626/Further.Strapi/branch/main/graph/badge.svg)](https://codecov.io/gh/yinchang0626/Further.Strapi)
-[![Coverage Tree](https://codecov.io/gh/yinchang0626/Further.Strapi/branch/main/graphs/tree.svg)](https://codecov.io/gh/yinchang0626/Further.Strapi)
 [![.NET](https://img.shields.io/badge/.NET-9.0-blue.svg?logo=dotnet)](https://dotnet.microsoft.com/)
 [![ABP Framework](https://img.shields.io/badge/ABP%20Framework-9.3.5-green.svg)](https://abp.io/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?logo=opensource)](LICENSE)
+
+[![Coverage Tree](https://codecov.io/gh/yinchang0626/Further.Strapi/branch/main/graphs/tree.svg)](https://codecov.io/gh/yinchang0626/Further.Strapi)
 
 A comprehensive .NET integration library for [Strapi v5](https://strapi.io/) headless CMS, built on top of the [ABP Framework](https://abp.io/).
 


### PR DESCRIPTION
- Remove hardcoded baseline coverage value from workflow
- Remove override_branch and override_commit parameters to let Codecov auto-detect
- Simplify coverage report to show current metrics only
- Clean up README badges layout: move Coverage Tree to separate line
- Improve workflow maintainability and reliability