### PR TITLE
[codex] Add Strapi list cancellation support

### DIFF
--- a/Further.Strapi.Contracts/Further/Strapi/ICollectionTypeProvider.cs
+++ b/Further.Strapi.Contracts/Further/Strapi/ICollectionTypeProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Further.Strapi;
@@ -22,5 +23,6 @@ public interface ICollectionTypeProvider<T>
         Action<FilterBuilder>? filter = null,
         Action<PopulateBuilder>? populate = null,
         Action<SortBuilder>? sort = null,
-        Action<PaginationBuilder>? pagination = null);
+        Action<PaginationBuilder>? pagination = null,
+        CancellationToken cancellationToken = default);
 }

--- a/Further.Strapi/Further/Strapi/CollectionTypeProvider.cs
+++ b/Further.Strapi/Further/Strapi/CollectionTypeProvider.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Volo.Abp.Json;
 
@@ -61,7 +62,8 @@ public class CollectionTypeProvider<T> : ICollectionTypeProvider<T>
         Action<FilterBuilder>? filter = null,
         Action<PopulateBuilder>? populate = null,
         Action<SortBuilder>? sort = null,
-        Action<PaginationBuilder>? pagination = null)
+        Action<PaginationBuilder>? pagination = null,
+        CancellationToken cancellationToken = default)
     {
         var client = CreateHttpClient();
         var path = StrapiProtocol.Paths.CollectionType<T>();
@@ -121,7 +123,7 @@ public class CollectionTypeProvider<T> : ICollectionTypeProvider<T>
         var query = queryParams.Count > 0 ? $"?{string.Join("&", queryParams)}" : "";
         var request = new HttpRequestMessage(HttpMethod.Get, $"{path}{query}");
 
-        var response = await client.SendAsync(request);
+        var response = await client.SendAsync(request, cancellationToken);
 
         var responseData = await StrapiProtocol.Response.DeserializeResponse<StrapiCollectionResponse<T>>(response, _jsonSerializer);
         


### PR DESCRIPTION
## Summary
- Add an optional cancellation token to `ICollectionTypeProvider<T>.GetListAsync`.
- Pass the token through to `HttpClient.SendAsync` for Strapi collection list requests.

## Why
Camping list content loading needs a bounded wait when Strapi is unavailable or slow, so the caller can return core availability data instead of blocking on optional content.

## Validation
- Built through the parent `Tourmap.Booking.Mediator` project successfully after this submodule update.

Parent PR: https://github.com/fs-tw/Tourmap/pull/1169